### PR TITLE
Fix invalid buffer handling from TCP socket

### DIFF
--- a/paho/utility.lua
+++ b/paho/utility.lua
@@ -106,11 +106,14 @@ local function socket_receive(socket_client, byte_count)
     byte_count = byte_count or 128   -- default  
     buffer = socket_client:recv(byte_count)
   else
-    response, error_message, partial_buffer = socket_client:receive("*a")
-    
+    response, error_message, partial_buffer = socket_client:receive(
+        byte_count or "*a")
+
     if response == nil then  --either error or partial response
       -- error_message-> "closed" | "timeout"
-      if error_message == "timeout" then error_message = nil end
+      if error_message == "timeout" then
+          error_message = nil
+      end
       result_buffer = partial_buffer
     else
       result_buffer = response


### PR DESCRIPTION
There was a problem with processing inbound messages from tcp socket.
The buffer retrieved from socket.receive was assumed as whole message.
But you could received only the part of message or the beginning of next
message. You should firstly read whole message size in the beginning of
message and than read exact size of message.